### PR TITLE
modify test to not depend on internal rmarkdown structure

### DIFF
--- a/tests/testthat/test-resumerStructure.R
+++ b/tests/testthat/test-resumerStructure.R
@@ -2,13 +2,9 @@ context("The resumer returns the proper list")
 
 resBlank <- resumer()
 
-test_that('resumer returns an rmakdown object with the correct length and names', {
-    expect_equal(length(resBlank), 9)
+test_that('resumer returns an rmakdown object with the correct class', {
     expect_named(resBlank)
     expect_is(resBlank, 'rmarkdown_output_format')
-    expect_equal(names(resBlank), c("knitr", "pandoc", "keep_md", "clean_supporting", 
-                                    "pre_knit", "post_knit",
-                                    "pre_processor", "intermediates_generator", "post_processor"))
 })
 
 unlink('resume.cls')


### PR DESCRIPTION
This test was probing the `rmarkdown_output_format` for a particular length and particular list element names. This is an internal rmarkdown data structure so can and does change. In the most recent version we added an element to this list which broke this test. This patch removes the test for specific length and list elements and just tests that the returned element is a named object of the correct class.
